### PR TITLE
Fix odd quotes

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'benchmark'
+require 'cswat'
+require 'csv'
+
+csvs = {normal: "1,2,3,4\n4,5,6,7\n"*10,
+        quote: "1,2,\"3\",4\n1,2,\"3\",4\n"*10,
+        quote_nl: "1,2,\"3\n4\",4\n1,2,\"3\n4\",4\n"*10}
+n = 10_000
+
+Benchmark.bm do |b|
+  csvs.each do |type, csv|
+    b.report("CSV #{type}:\t")   { n.times { CSV.parse csv } }
+    b.report("CSWat #{type}:\t") { n.times { CSWat.parse csv } }
+  end
+end
+

--- a/test/test_features.rb
+++ b/test/test_features.rb
@@ -169,13 +169,13 @@ class TestFeatures < Minitest::Test
                  CSWat.parse_line(input, nonstandard_quote: true,
                                   liberal_parsing: true))
 
-    input = '""quoted" field"'
+    input = 'a "quoted" field with 5" of wat'
     assert_raise(CSWat::MalformedCSVError) do
         CSWat.parse_line(input)
     end
-    assert_equal(['"quoted" field'],
-                 CSWat.parse_line(input, nonstandard_quote: true))
-    assert_equal(['"quoted" field'],
+    assert_equal([input],
+                 CSWat.parse_line("\"#{input}\"", nonstandard_quote: true))
+    assert_equal([input],
                  CSWat.parse_line(input, nonstandard_quote: true,
                                   liberal_parsing: true))
   end


### PR DESCRIPTION
This possibly has some performance hit as I had to replace single character checks (e.g. `part[0] == '"'`) with some non-obvious regex checks (e.g. `part[0] =~ /\A"("")*(\z|[^"])/`).
