### PR TITLE
Graceful error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,17 @@ Or install it yourself as:
 
 `CSWat` is basically a fork of Ruby masters branch CSV library, renamed to
 `CSWat` to avoid clashes. Use is as you would use `CSV`, with addition to a few
-added options to relax some csv restrictions around the standards. For now ther
-is only one new option: `nonstandard_quote` which is a boolean value determinig
-if it should try to handle non-standard quoting style of PHP standard library
-csv implementation. Look at the [tests] for more information.
+added options to relax some csv restrictions around the standards. For now there
+are a few new options:
+
++ `nonstandard_quote` which is a boolean value determinig if it should try to
+  handle non-standard quoting style of PHP standard library csv implementation.
+  Look at the [tests] for more information.
++ `graceful_errors` which overrides default behaviour of raising MalformedCSV
+  exceptions and instead returns them as rows.
++ `accept_backslash_escape` which causes the parser to accept escaping of quote
+  character with a backslash (e.g. `\"`) the same as standard double-quote
+  escaping (e.g. `""`).
 
 Additionally CSWat provides a niftly small executable (`cswat`, obviously) which
 reads from `ARGF` and prints each row it parsed with `p` so you can see how

--- a/lib/cswat.rb
+++ b/lib/cswat.rb
@@ -1970,7 +1970,7 @@ class CSWat
         end
       rescue MalformedCSVError => e
         if @graceful_errors
-          return e
+          break e
         else
           raise e
         end

--- a/test/test_benchmarks.rb
+++ b/test/test_benchmarks.rb
@@ -16,4 +16,11 @@ class TestCSWat < Minitest::Benchmark
                   nonstandard_quote: true)
     end
   end
+
+  def bench_nonstandar_quote_performance
+    assert_performance_linear 0.999 do |n| # n is a range value
+      CSWat.parse("1,2.1,\"Dwayne \"The Rock\" Johnson\",-1\n"*n,
+                  graceful_errors: true)
+    end
+  end
 end

--- a/test/test_features.rb
+++ b/test/test_features.rb
@@ -180,6 +180,16 @@ class TestFeatures < Minitest::Test
                                   liberal_parsing: true))
   end
 
+  def test_graceful_errors
+    input = "e,f,g,h\"\na,b,c,d"
+    assert_raise(CSWat::MalformedCSVError) do
+        CSWat.parse_line(input)
+    end
+    result = CSWat.parse(input, nonstandard_quote: true, graceful_errors: true)
+    assert_instance_of(CSWat::MalformedCSVError, result[0])
+    assert_equal(["a", "b", "c", "d"], result[1])
+  end
+
   def test_nonstandard_quotes_and_liberal_parsing
     input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
     assert_raise(CSWat::MalformedCSVError) do


### PR DESCRIPTION
passes the MalformedCSV exception as results instead of raising them
