### PR TITLE
throw on row_sep occurances in quote for graceful_errors

### DIFF
--- a/lib/cswat.rb
+++ b/lib/cswat.rb
@@ -1521,7 +1521,12 @@ class CSWat
   # <b><tt>:graceful_errors</tt></b>::    When set to +true+, instead of raising
   #                                       MalformedCSVError, pass the Exceptions
   #                                       as the row object and go on with the
-  #                                       next row.
+  #                                       next row. Note that enabling this flag
+  #                                       will result in total intolorance to
+  #                                       row seperator inside quoted columns
+  #                                       because having both of these features
+  #                                       will make it very hard to find out
+  #                                       exactly on which row things went wrong.
   # <b><tt>:accept_backslash_escape</tt></b>::  accepts backslash escaping of the
   #                                             quote character *as well as*
   #                                             double quoting.
@@ -1942,7 +1947,11 @@ class CSWat
 
         if in_extended_col
           # if we're at eof?(), a quoted field wasn't closed...
-          if @io.eof?
+          # Also in case of activating graceful errors flag, we gotta have to
+          # forgo using row seperators inside quotes as it effectively hinders the
+          # ability to know exactly which row was at fault and where we should
+          # start off again.
+          if @io.eof? || @graceful_errors
             raise MalformedCSVError,
               "Unclosed quoted field on line #{lineno + 1}."
           elsif @field_size_limit and csv.last.size >= @field_size_limit

--- a/test/test_features.rb
+++ b/test/test_features.rb
@@ -181,13 +181,14 @@ class TestFeatures < Minitest::Test
   end
 
   def test_graceful_errors
-    input = "e,f,g,h\"\na,b,c,d"
+    input = "a,b,c,d\ne,f,\",h\ni,j,k,l"
     assert_raise(CSWat::MalformedCSVError) do
-        CSWat.parse_line(input)
+        CSWat.parse(input)
     end
     result = CSWat.parse(input, nonstandard_quote: true, graceful_errors: true)
-    assert_instance_of(CSWat::MalformedCSVError, result[0])
-    assert_equal(["a", "b", "c", "d"], result[1])
+    assert_equal(["a", "b", "c", "d"], result[0])
+    assert_instance_of(CSWat::MalformedCSVError, result[1])
+    assert_equal(["i", "j", "k", "l"], result[2])
   end
 
   def test_nonstandard_quotes_and_liberal_parsing


### PR DESCRIPTION
If we try to handle both row separators inside quotation and graceful error handling, for a lot of the cases we are not going to be able to find the real cause of the issue. Therefore now graceful_errors flag causes the parser to throw if it saw a row separator inside a quoted column. 
