### PR TITLE
Use double splat for keyword args to get rid of deprecation warning

### DIFF
--- a/lib/cswat.rb
+++ b/lib/cswat.rb
@@ -1271,7 +1271,7 @@ class CSWat
     # decorator
     file_opts = {universal_newline: false}.merge(options)
     begin
-      f = File.open(*args, file_opts)
+      f = File.open(*args, **file_opts)
     rescue ArgumentError => e
       raise unless /needs binmode/ =~ e.message and args.size == 1
       args << "rb"


### PR DESCRIPTION
Part of changes to separation of positional and keyword arguments introduced a deprecation warning in Ruby 2.7.