### PR TITLE
Fix deprecated assertions

### DIFF
--- a/cswat.gemspec
+++ b/cswat.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", "~> 1.1"
   spec.add_development_dependency "minitest-focus", "~> 1.1"
   spec.add_development_dependency "test-unit", "~> 3.2.1"
+  spec.add_development_dependency "pry", "~> 0.14"
 end

--- a/test/test_benchmarks.rb
+++ b/test/test_benchmarks.rb
@@ -10,14 +10,14 @@ class TestCSWat < Minitest::Benchmark
     end
   end
 
-  def bench_nonstandar_quote_performance
+  def bench_nonstandar_quote_performance_with_nonstandard_quote
     assert_performance_linear 0.999 do |n| # n is a range value
       CSWat.parse("1,2.1,\"Dwayne \"The Rock\" Johnson\",-1\n"*n,
                   nonstandard_quote: true)
     end
   end
 
-  def bench_nonstandar_quote_performance
+  def bench_nonstandar_quote_performance_with_graceful_errors
     assert_performance_linear 0.999 do |n| # n is a range value
       CSWat.parse("1,2.1,\"Dwayne \"The Rock\" Johnson\",-1\n"*n,
                   graceful_errors: true)

--- a/test/test_csv_parsing.rb
+++ b/test/test_csv_parsing.rb
@@ -87,7 +87,7 @@ class TestCSVParsing < Minitest::Test
 
   def test_james_edge_cases
     # A read at eof? should return nil.
-    assert_equal(nil, CSWat.parse_line(""))
+    assert_nil CSWat.parse_line("")
     #
     # With Ruby 1.8 CSV it's impossible to tell an empty line from a line
     # containing a single +nil+ field.  The old CSV library returns
@@ -145,7 +145,7 @@ class TestCSVParsing < Minitest::Test
     begin
       loop do
         assert_not_nil(csv.shift)
-        assert_send([csv.lineno, :<, 4])
+        assert_operator(csv.lineno, :<, 4)
       end
     rescue CSWat::MalformedCSVError
       assert_equal( "Unquoted fields do not allow \\r or \\n (line 4).",
@@ -169,7 +169,7 @@ class TestCSVParsing < Minitest::Test
     begin
       loop do
         assert_not_nil(csv.shift)
-        assert_send([csv.lineno, :<, 4])
+        assert_operator(csv.lineno, :<, 4)
       end
     rescue CSWat::MalformedCSVError
       assert_equal("Illegal quoting in line 4.", $!.message)

--- a/test/test_interface.rb
+++ b/test/test_interface.rb
@@ -75,7 +75,7 @@ class TestInterface < Minitest::Test
   end
 
   def test_parse_line_with_empty_lines
-    assert_equal(nil,       CSWat.parse_line(""))  # to signal eof
+    assert_nil              CSWat.parse_line("")  # to signal eof
     assert_equal(Array.new, CSWat.parse_line("\n1,2,3"))
   end
 
@@ -106,7 +106,7 @@ class TestInterface < Minitest::Test
     CSWat.open(@path, "rb+", col_sep: "\t", row_sep: "\r\n") do |csv|
       assert_equal(@expected.shift, csv.shift)
       assert_equal(@expected.shift, csv.shift)
-      assert_equal(nil, csv.shift)
+      assert_nil csv.shift
     end
   end
 
@@ -279,23 +279,33 @@ class TestInterface < Minitest::Test
     end
   end
 
-  def test_append  # aliased add_row() and puts()
+  def test_append_1  # aliased add_row() and puts()
     File.unlink(@path)
 
     CSWat.open(@path, "wb", col_sep: "\t", row_sep: "\r\n") do |csv|
       @expected.each { |row| csv << row }
     end
 
-    test_shift
+    CSWat.open(@path, "rb+", col_sep: "\t", row_sep: "\r\n") do |csv|
+      assert_equal(@expected.shift, csv.shift)
+      assert_equal(@expected.shift, csv.shift)
+      assert_nil csv.shift
+    end
+  end
 
-    # same thing using CSV::Row objects
+  # using CSV::Row objects
+  def test_append_2
     File.unlink(@path)
 
     CSWat.open(@path, "wb", col_sep: "\t", row_sep: "\r\n") do |csv|
       @expected.each { |row| csv << CSWat::Row.new(Array.new, row) }
     end
 
-    test_shift
+    CSWat.open(@path, "rb+", col_sep: "\t", row_sep: "\r\n") do |csv|
+      assert_equal(@expected.shift, csv.shift)
+      assert_equal(@expected.shift, csv.shift)
+      assert_nil csv.shift
+    end
   end
 
   ### Test Read and Write Interface ###

--- a/test/test_row.rb
+++ b/test/test_row.rb
@@ -66,8 +66,8 @@ class TestRow < Minitest::Test
     assert_equal(4, @row.field("A", 1))
     assert_equal(4, @row.field("A", 2))
     assert_equal(4, @row.field("A", 3))
-    assert_equal(nil, @row.field("A", 4))
-    assert_equal(nil, @row.field("A", 5))
+    assert_nil @row.field("A", 4)
+    assert_nil @row.field("A", 5)
   end
 
   def test_fetch
@@ -227,7 +227,7 @@ class TestRow < Minitest::Test
     assert_equal(0, @row.index("A"))
     assert_equal(1, @row.index("B"))
     assert_equal(2, @row.index("C"))
-    assert_equal(nil, @row.index("Z"))
+    assert_nil @row.index("Z")
 
     # with minimum index
     assert_equal(0, @row.index("A"))
@@ -236,15 +236,15 @@ class TestRow < Minitest::Test
     assert_equal(3, @row.index("A", 2))
     assert_equal(3, @row.index("A", 3))
     assert_equal(4, @row.index("A", 4))
-    assert_equal(nil, @row.index("A", 5))
+    assert_nil @row.index("A", 5)
   end
 
   def test_queries
     # headers
-    assert_send([@row, :header?, "A"])
-    assert_send([@row, :header?, "C"])
-    assert_not_send([@row, :header?, "Z"])
-    assert_send([@row, :include?, "A"])  # alias
+    assert @row.header?("A")
+    assert @row.header?("C")
+    refute @row.header?("z")
+    assert @row.include?("A") # alias
 
     # fields
     assert(@row.field?(4))
@@ -257,14 +257,26 @@ class TestRow < Minitest::Test
     ary = @row.to_a
     @row.each do |pair|
       assert_equal(ary.first.first, pair.first)
-      assert_equal(ary.shift.last, pair.last)
+
+      if ary.first.last.nil?
+        assert_nil ary.shift.last
+        assert_nil pair.last
+      else
+        assert_equal(ary.shift.last, pair.last)
+      end
     end
 
     # hash style
     ary = @row.to_a
     @row.each do |header, field|
       assert_equal(ary.first.first, header)
-      assert_equal(ary.shift.last, field)
+
+      if ary.first.last.nil?
+        assert_nil ary.shift.last
+        assert_nil field
+      else
+        assert_equal(ary.shift.last, field)
+      end
     end
 
     # verify that we can chain the call
@@ -322,10 +334,11 @@ class TestRow < Minitest::Test
   end
 
   def test_inspect_encoding_is_ascii_compatible
-    assert_send([Encoding, :compatible?,
-                 Encoding.find("US-ASCII"),
-                 @row.inspect.encoding],
-                "inspect() was not ASCII compatible.")
+    assert Encoding.compatible?(
+      Encoding.find("US-ASCII"),
+      @row.inspect.encoding
+    ),
+    "inspect() was not ASCII compatible."
   end
 
   def test_inspect_shows_symbol_headers_as_bare_attributes

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -54,7 +54,7 @@ class TestTable < Minitest::Test
     ##################
     # by row
     @rows.each_index { |i| assert_equal(@rows[i], @table[i]) }
-    assert_equal(nil, @table[100])  # empty row
+    assert_nil @table[100]  # empty row
 
     # by row with Range
     assert_equal([@table[1], @table[2]], @table[1..2])
@@ -418,9 +418,10 @@ class TestTable < Minitest::Test
   end
 
   def test_inspect_encoding_is_ascii_compatible
-    assert_send([Encoding, :compatible?,
-                 Encoding.find("US-ASCII"),
-                 @table.inspect.encoding],
-            "inspect() was not ASCII compatible." )
+    assert Encoding.compatible?(
+      Encoding.find("US-ASCII"),
+      @table.inspect.encoding
+    ),
+    "inspect() was not ASCII compatible."
   end
 end


### PR DESCRIPTION
Replace deprecated asseriton syntaxes to get rid of noise when running test suite

BEFORE
![minitest-before](https://user-images.githubusercontent.com/3275302/116675574-a3a78300-a9ae-11eb-90e7-1b1f5cb19ba5.gif)

AFTER
![minitest-after](https://user-images.githubusercontent.com/3275302/116675583-a73b0a00-a9ae-11eb-800e-538b45a8fa90.gif)
