### PR TITLE
Add option to guard for too long lines consuming too much memory

### DIFF
--- a/lib/cswat.rb
+++ b/lib/cswat.rb
@@ -1858,7 +1858,7 @@ class CSWat
         end
 
         if @max_line_length_bytes > 0 && parse.bytesize >= @max_line_length_bytes
-          msg = "Too long line at #{lineno + 1}. Exceeded or equaled the size limit of #{@max_line_length_bytes}"
+          msg = "Too long line at #{lineno + 1}. Exceeded or equaled the size limit of #{@max_line_length_bytes} bytes"
           raise MalformedCSVError, msg
         end
 

--- a/test/test_csv_parsing.rb
+++ b/test/test_csv_parsing.rb
@@ -189,6 +189,11 @@ class TestCSVParsing < Minitest::Test
                              field_size_limit: 2048 )
   end
 
+  def test_line_size_limit
+    assert_parse_errors_out( 'valid,fields,"' + BIG_DATA + '"',
+                             max_line_length_bytes: 8 )
+  end
+
   private
 
   def assert_parse_errors_out(*args)

--- a/test/test_csv_parsing.rb
+++ b/test/test_csv_parsing.rb
@@ -190,8 +190,9 @@ class TestCSVParsing < Minitest::Test
   end
 
   def test_line_size_limit
-    assert_parse_errors_out( 'valid,fields,"' + BIG_DATA + '"',
-                             max_line_length_bytes: 8 )
+    assert_raise_with_message(CSWat::MalformedCSVError, "Too long line at 1. Exceeded or equaled the size limit of 8") {
+      CSWat.parse('valid,fields,"' + BIG_DATA + '"', max_line_length_bytes: 8)
+    }
   end
 
   private

--- a/test/test_csv_parsing.rb
+++ b/test/test_csv_parsing.rb
@@ -190,7 +190,7 @@ class TestCSVParsing < Minitest::Test
   end
 
   def test_line_size_limit
-    assert_raise_with_message(CSWat::MalformedCSVError, "Too long line at 1. Exceeded or equaled the size limit of 8") {
+    assert_raise_with_message(CSWat::MalformedCSVError, "Too long line at 1. Exceeded or equaled the size limit of 8 bytes") {
       CSWat.parse('valid,fields,"' + BIG_DATA + '"', max_line_length_bytes: 8)
     }
   end


### PR DESCRIPTION
* Add limitation for max line length to counter high memory usage
* Throw MalformedCSVError when `gets` returns a string that's bytesize is equal or greater than the set limit
* Edge case: the line is exactly as long as the limit, still throws as there is no way to know whether we parsed up until the line separator or the byte limit was reached